### PR TITLE
Configure `SWXSOC_MISSION` Env Var on init of Instrument Package

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -25,7 +25,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=padre processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request_target, pull_request]
+on: [pull_request_target]
 
 jobs:
   test-and-upload:

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -25,7 +25,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=PRODUCTION -e processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=DEVELOPMENT -e processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request_target]
+on: [pull_request_target, pull_request]
 
 jobs:
   test-and-upload:
@@ -25,7 +25,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=PRODUCTION -e processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -25,4 +25,4 @@ jobs:
         PLATFORM: 'docker'
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
-        env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -25,4 +25,5 @@ jobs:
         PLATFORM: 'docker'
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
-      env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      env: 
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -23,7 +23,6 @@ jobs:
       run: pytest --pyargs padre_meddea --cov padre_meddea
       env:
         PLATFORM: 'docker'
-        SWXSOC_MISSION: padre
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
         env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,6 @@ jobs:
       env:
         #
         PLATFORM: ${{ matrix.platform }}
-        SWXSOC_MISSION: padre
         #
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -10,8 +10,8 @@ except ImportError:
     version_tuple = (0, 0, "unknown version")
 
 # Get SWXSOC_MISSIONS environment variable if it exists or use default for mission
-SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")  # noqa: E403
-os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION  # noqa: E403
+SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")  # noqa: E402
+os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION  # noqa: E402
 
 from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
 

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -13,11 +13,11 @@ except ImportError:
 SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")
 os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION
 
-from swxsoc import (
+from swxsoc import (  # noqa: E402
     config as swxsoc_config,
     log as swxsoc_log,
     print_config,
-)  # noqa: E402
+)
 
 # Load user configuration
 config = swxsoc_config

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -9,9 +9,9 @@ except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
 
-# Set up the mission environmental variables
-os.environ["SWXSOC_MISSION"] = "padre"
-os.environ["LAMBDA_ENVIRONMENT"] = "PRODUCTION"
+# Get SWXSOC_MISSIONS environment variable if it exists or use default for mission
+SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")  # noqa: E403
+os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION  # noqa: E403
 
 from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
 

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 
 # Set up the mission environmental variables
 os.environ["SWXSOC_MISSION"] = "padre"
+os.environ["LAMBDA_ENVIRONMENT"] = "PRODUCTION"
 
 from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
 

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -1,4 +1,5 @@
 # see license/LICENSE.rst
+import os
 from pathlib import Path
 
 try:
@@ -7,6 +8,9 @@ try:
 except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
+
+# Set up the mission environmental variables
+os.environ["SWXSOC_MISSION"] = "padre"
 
 from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
 

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -10,10 +10,10 @@ except ImportError:
     version_tuple = (0, 0, "unknown version")
 
 # Get SWXSOC_MISSIONS environment variable if it exists or use default for mission
-SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")  # noqa: E402
-os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION  # noqa: E402
+SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")
+os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION
 
-from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
+from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config # noqa: E402
 
 # Load user configuration
 config = swxsoc_config

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -13,7 +13,11 @@ except ImportError:
 SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")
 os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION
 
-from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config # noqa: E402
+from swxsoc import (
+    config as swxsoc_config,
+    log as swxsoc_log,
+    print_config,
+)  # noqa: E402
 
 # Load user configuration
 config = swxsoc_config

--- a/padre_meddea/calibration/simul_spec.py
+++ b/padre_meddea/calibration/simul_spec.py
@@ -400,9 +400,9 @@ def generate_photon_list_file(output_file=True):
             flare_ph_num = index.sum()
             print(f"Got {flare_ph_num} flare photons.")
 
-            fl_ph_wait_times[ph_counter : ph_counter + flare_ph_num] = (
-                this_fl_ph_wait_times[index]
-            )
+            fl_ph_wait_times[
+                ph_counter : ph_counter + flare_ph_num
+            ] = this_fl_ph_wait_times[index]
             fl_ph_arrival_times[ph_counter : ph_counter + flare_ph_num] = (
                 this_fl_ph_arrival_times[index] + this_time * u.s
             )

--- a/padre_meddea/calibration/simul_spec.py
+++ b/padre_meddea/calibration/simul_spec.py
@@ -400,9 +400,9 @@ def generate_photon_list_file(output_file=True):
             flare_ph_num = index.sum()
             print(f"Got {flare_ph_num} flare photons.")
 
-            fl_ph_wait_times[
-                ph_counter : ph_counter + flare_ph_num
-            ] = this_fl_ph_wait_times[index]
+            fl_ph_wait_times[ph_counter : ph_counter + flare_ph_num] = (
+                this_fl_ph_wait_times[index]
+            )
             fl_ph_arrival_times[ph_counter : ph_counter + flare_ph_num] = (
                 this_fl_ph_arrival_times[index] + this_time * u.s
             )


### PR DESCRIPTION
In this PR, we configure the environmental variable `SWXSOC_MISSION` on initialization or import of the instrument package so that the `swxsoc` package can use the right mission configuration (in this case `padre`) without the need for the user to set-up a custom configuration or set the environmental variable themselves. 

It doesn't overwrite if the `SWXSOC_MISSION` environmental variable already exists, so that users can still change the configured mission if they'd like within their development environment. 

`swxsoc` mission configuration file maintained by us for the missions we support: https://github.com/swxsoc/swxsoc/blob/main/swxsoc/data/config.yml

More info on how to customize the `swxsoc` core package configuration can be found here: https://swxsoc.readthedocs.io/en/latest/user-guide/customization.html


Other fixes in this PR:
- Fixes a broken workflow which runs tests within the container
- Also updates a workflow so that it processes the file to the correct directory within the container `tmp` 